### PR TITLE
Add Staff Directory WordPress Plugin v1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # AW Demo Repository
 
 This repository contains WordPress plugins and themes.
+
+## Current Plugins
+
+- **Staff Directory** - A comprehensive staff management plugin with ACF Pro integration

--- a/staff-directory/README.md
+++ b/staff-directory/README.md
@@ -1,0 +1,178 @@
+# Staff Directory WordPress Plugin
+
+A comprehensive WordPress plugin for managing staff members with Advanced Custom Fields Pro integration.
+
+## Features
+
+- **Custom Post Type**: Dedicated 'staff' post type with menu order support
+- **ACF Pro Integration**: Rich field groups for staff information and social media
+- **Flexible Shortcode**: `[staff_directory]` with multiple sorting and display options
+- **Single Staff Pages**: Custom template for individual staff member profiles
+- **Responsive Design**: Mobile-friendly card/grid layouts
+- **Department Organization**: Built-in department taxonomy and filtering
+
+## Requirements
+
+- WordPress 5.0 or higher
+- PHP 7.4 or higher
+- Advanced Custom Fields Pro plugin
+
+## Installation
+
+1. Upload the `staff-directory` folder to your `/wp-content/plugins/` directory
+2. Activate the plugin through the 'Plugins' menu in WordPress
+3. Ensure ACF Pro is installed and activated
+4. Start adding staff members through the WordPress admin
+
+## Usage
+
+### Adding Staff Members
+
+1. Go to **Staff Directory > Add New Staff Member** in your WordPress admin
+2. Fill in the staff information fields:
+   - Full Name
+   - Job Title
+   - Email Address
+   - Phone Number (optional)
+   - Birth Date (optional)
+   - Department
+   - Biography
+   - Social Media Links
+3. Set a featured image for the staff photo
+4. Use the **Order** field in Page Attributes to control display order
+5. Publish the staff member
+
+### Displaying Staff Directory
+
+Use the `[staff_directory]` shortcode in any post, page, or widget to display your staff members.
+
+#### Shortcode Parameters
+
+```
+[staff_directory orderby="menu_order" columns="3" limit="12" department="marketing"]
+```
+
+**Available Parameters:**
+
+- `orderby`: How to sort staff members
+  - `menu_order` (default) - Use the order set in admin
+  - `alphabetical` - Sort by name A-Z
+  - `department` - Group by department
+- `columns`: Number of columns in grid (1-6, default: 3)
+- `limit`: Number of staff to display (-1 for all, default: -1)
+- `department`: Filter by specific department slug
+
+#### Example Shortcodes
+
+```html
+<!-- Default 3-column grid, menu order -->
+[staff_directory]
+
+<!-- 4-column grid, alphabetical order -->
+[staff_directory orderby="alphabetical" columns="4"]
+
+<!-- Show only marketing department -->
+[staff_directory department="marketing"]
+
+<!-- 2-column grid, limit to 6 staff members -->
+[staff_directory columns="2" limit="6"]
+```
+
+### Single Staff Pages
+
+Each staff member automatically gets their own page displaying:
+
+- Staff photo
+- Full contact information
+- Biography and additional content
+- Social media links
+- Back to directory navigation
+
+URLs follow the pattern: `yoursite.com/staff/staff-member-name/`
+
+## Staff Fields
+
+The plugin creates the following fields for each staff member:
+
+### Basic Information
+- **Full Name** (required)
+- **Job Title** (required)
+- **Email Address** (required)
+- **Phone Number**
+- **Birth Date**
+- **Department** (dropdown)
+- **Biography** (textarea)
+
+### Social Media
+- **Social Links** (repeater field)
+  - Platform (LinkedIn, Twitter, Facebook, Instagram, GitHub, etc.)
+  - URL
+
+## Departments
+
+Available departments include:
+- Executive
+- Marketing
+- Sales
+- Human Resources
+- Information Technology
+- Finance
+- Operations
+- Customer Service
+- Other
+
+## Customization
+
+### Theme Integration
+
+The plugin uses its own templates but respects your theme's styling. You can override the single staff template by copying `single-staff.php` to your theme directory.
+
+### CSS Customization
+
+The plugin includes comprehensive CSS that can be customized through:
+- Theme's `style.css`
+- WordPress Customizer
+- Custom CSS plugins
+
+Key CSS classes:
+- `.staff-directory-container` - Main container
+- `.staff-directory-grid` - Grid wrapper
+- `.staff-directory-card` - Individual staff cards
+- `.staff-single-container` - Single page wrapper
+
+## File Structure
+
+```
+staff-directory/
+├── staff-directory.php              # Main plugin file
+├── includes/
+│   ├── class-staff-post-type.php    # Post type registration
+│   ├── class-staff-acf-fields.php   # ACF field groups
+│   ├── class-staff-shortcode.php    # Shortcode handler
+│   └── class-staff-templates.php    # Template loader
+├── templates/
+│   └── single-staff.php             # Single staff template
+├── assets/
+│   └── css/
+│       └── staff-directory.css      # Frontend styles
+└── README.md                        # Documentation
+```
+
+## Support
+
+For support and feature requests, please use the GitHub repository issues page.
+
+## Changelog
+
+### Version 1.0.0
+- Initial release
+- Custom staff post type
+- ACF Pro integration
+- Flexible shortcode with sorting options
+- Responsive design
+- Single staff page templates
+- Department organization
+
+## License
+
+GPL v2 or later

--- a/staff-directory/assets/css/staff-directory.css
+++ b/staff-directory/assets/css/staff-directory.css
@@ -1,0 +1,502 @@
+/**
+ * Staff Directory Plugin Styles
+ * 
+ * Frontend styling for staff directory shortcode and single pages
+ */
+
+/* ==========================================================================
+   Staff Directory Grid Layout
+   ========================================================================== */
+
+.staff-directory-container {
+    margin: 2rem 0;
+}
+
+.staff-directory-grid {
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+/* Column-specific layouts */
+.staff-directory-columns-1 {
+    grid-template-columns: 1fr;
+}
+
+.staff-directory-columns-2 {
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    max-width: 800px;
+}
+
+.staff-directory-columns-3 {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.staff-directory-columns-4 {
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+}
+
+.staff-directory-columns-5 {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.staff-directory-columns-6 {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+/* ==========================================================================
+   Staff Card Styles
+   ========================================================================== */
+
+.staff-directory-card {
+    background: #ffffff;
+    border: 1px solid #e1e5e9;
+    border-radius: 8px;
+    overflow: hidden;
+    transition: all 0.3s ease;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.staff-directory-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    border-color: #007cba;
+}
+
+.staff-card-inner {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+/* Card Image */
+.staff-card-image {
+    position: relative;
+    overflow: hidden;
+    background: #f7f7f7;
+}
+
+.staff-card-image img {
+    width: 100%;
+    height: 250px;
+    object-fit: cover;
+    transition: transform 0.3s ease;
+}
+
+.staff-card-image:hover img {
+    transform: scale(1.05);
+}
+
+.staff-card-image a {
+    display: block;
+    text-decoration: none;
+}
+
+/* Placeholder image for staff without photos */
+.staff-card-no-image .staff-placeholder-image {
+    height: 250px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, #f0f0f0 0%, #e0e0e0 100%);
+    color: #666;
+}
+
+.staff-placeholder-icon {
+    font-size: 4rem;
+    opacity: 0.6;
+}
+
+/* Card Content */
+.staff-card-content {
+    padding: 1.5rem;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+.staff-card-name {
+    margin: 0 0 0.5rem 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+    line-height: 1.3;
+}
+
+.staff-card-name a {
+    color: #2c3e50;
+    text-decoration: none;
+    transition: color 0.2s ease;
+}
+
+.staff-card-name a:hover {
+    color: #007cba;
+}
+
+.staff-card-title {
+    margin: 0 0 0.75rem 0;
+    color: #007cba;
+    font-weight: 500;
+    font-size: 0.95rem;
+}
+
+.staff-card-department {
+    margin: 0 0 0.75rem 0;
+    color: #666;
+    font-size: 0.9rem;
+    padding: 0.25rem 0.5rem;
+    background: #f8f9fa;
+    border-radius: 4px;
+    display: inline-block;
+    width: fit-content;
+}
+
+.staff-card-email {
+    margin: 0 0 1rem 0;
+    font-size: 0.9rem;
+}
+
+.staff-card-email a {
+    color: #007cba;
+    text-decoration: none;
+}
+
+.staff-card-email a:hover {
+    text-decoration: underline;
+}
+
+.staff-card-actions {
+    margin-top: auto;
+    padding-top: 1rem;
+}
+
+.staff-card-link {
+    display: inline-block;
+    background: #007cba;
+    color: white;
+    padding: 0.5rem 1rem;
+    text-decoration: none;
+    border-radius: 4px;
+    font-size: 0.9rem;
+    font-weight: 500;
+    transition: background-color 0.2s ease;
+}
+
+.staff-card-link:hover {
+    background: #005a87;
+    color: white;
+    text-decoration: none;
+}
+
+/* No results message */
+.staff-directory-no-results {
+    text-align: center;
+    color: #666;
+    font-style: italic;
+    margin: 2rem 0;
+    padding: 2rem;
+    background: #f8f9fa;
+    border-radius: 8px;
+}
+
+/* ==========================================================================
+   Single Staff Page Styles
+   ========================================================================== */
+
+.staff-single-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 2rem 1rem;
+}
+
+.staff-single-post {
+    background: white;
+    border-radius: 8px;
+    overflow: hidden;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.staff-single-content {
+    padding: 2rem;
+}
+
+/* Single Staff Header */
+.staff-single-header {
+    margin-bottom: 2rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 2px solid #f0f0f0;
+}
+
+.staff-header-inner {
+    display: grid;
+    grid-template-columns: 200px 1fr;
+    gap: 2rem;
+    align-items: start;
+}
+
+.staff-single-image img {
+    width: 100%;
+    height: 200px;
+    object-fit: cover;
+    border-radius: 8px;
+}
+
+.staff-single-no-image .staff-placeholder-large {
+    width: 100%;
+    height: 200px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, #f0f0f0 0%, #e0e0e0 100%);
+    border-radius: 8px;
+    color: #666;
+}
+
+.staff-placeholder-large .staff-placeholder-icon {
+    font-size: 5rem;
+    opacity: 0.6;
+}
+
+.staff-single-name {
+    margin: 0 0 0.5rem 0;
+    font-size: 2rem;
+    font-weight: 700;
+    color: #2c3e50;
+    line-height: 1.2;
+}
+
+.staff-single-title {
+    margin: 0 0 1rem 0;
+    font-size: 1.25rem;
+    color: #007cba;
+    font-weight: 500;
+}
+
+.staff-single-department {
+    margin: 0;
+    color: #666;
+    font-size: 1rem;
+}
+
+.staff-single-department strong {
+    color: #2c3e50;
+}
+
+/* Contact Information Section */
+.staff-contact-section {
+    margin-bottom: 2rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid #f0f0f0;
+}
+
+.staff-contact-section h2 {
+    margin: 0 0 1rem 0;
+    font-size: 1.5rem;
+    color: #2c3e50;
+    border-bottom: 2px solid #007cba;
+    padding-bottom: 0.5rem;
+    display: inline-block;
+}
+
+.staff-contact-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1rem;
+}
+
+.staff-contact-item {
+    padding: 1rem;
+    background: #f8f9fa;
+    border-radius: 6px;
+    border-left: 4px solid #007cba;
+}
+
+.staff-contact-item strong {
+    display: block;
+    margin-bottom: 0.25rem;
+    color: #2c3e50;
+}
+
+.staff-contact-item a {
+    color: #007cba;
+    text-decoration: none;
+}
+
+.staff-contact-item a:hover {
+    text-decoration: underline;
+}
+
+/* Biography Section */
+.staff-bio-section {
+    margin-bottom: 2rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid #f0f0f0;
+}
+
+.staff-bio-section h2 {
+    margin: 0 0 1rem 0;
+    font-size: 1.5rem;
+    color: #2c3e50;
+    border-bottom: 2px solid #007cba;
+    padding-bottom: 0.5rem;
+    display: inline-block;
+}
+
+.staff-bio-content,
+.staff-post-content {
+    line-height: 1.7;
+    color: #333;
+}
+
+.staff-bio-content p,
+.staff-post-content p {
+    margin-bottom: 1rem;
+}
+
+/* Social Media Section */
+.staff-social-section {
+    margin-bottom: 2rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid #f0f0f0;
+}
+
+.staff-social-section h2 {
+    margin: 0 0 1rem 0;
+    font-size: 1.5rem;
+    color: #2c3e50;
+    border-bottom: 2px solid #007cba;
+    padding-bottom: 0.5rem;
+    display: inline-block;
+}
+
+.staff-social-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.staff-social-link {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1rem;
+    background: #f8f9fa;
+    border: 1px solid #e1e5e9;
+    border-radius: 6px;
+    text-decoration: none;
+    color: #2c3e50;
+    transition: all 0.2s ease;
+}
+
+.staff-social-link:hover {
+    background: #007cba;
+    color: white;
+    border-color: #007cba;
+    text-decoration: none;
+    transform: translateY(-1px);
+}
+
+.staff-social-icon {
+    font-size: 1.2rem;
+}
+
+.staff-social-label {
+    font-weight: 500;
+}
+
+/* Navigation */
+.staff-navigation {
+    text-align: center;
+}
+
+.staff-back-link {
+    display: inline-block;
+    color: #007cba;
+    text-decoration: none;
+    font-weight: 500;
+    padding: 0.5rem 1rem;
+    border: 2px solid #007cba;
+    border-radius: 6px;
+    transition: all 0.2s ease;
+}
+
+.staff-back-link:hover {
+    background: #007cba;
+    color: white;
+    text-decoration: none;
+}
+
+/* ==========================================================================
+   Responsive Design
+   ========================================================================== */
+
+@media (max-width: 768px) {
+    /* Grid adjustments for mobile */
+    .staff-directory-grid {
+        grid-template-columns: 1fr;
+        gap: 1.5rem;
+    }
+    
+    .staff-directory-columns-1,
+    .staff-directory-columns-2,
+    .staff-directory-columns-3,
+    .staff-directory-columns-4,
+    .staff-directory-columns-5,
+    .staff-directory-columns-6 {
+        grid-template-columns: 1fr;
+    }
+    
+    /* Single staff page mobile adjustments */
+    .staff-single-container {
+        padding: 1rem;
+    }
+    
+    .staff-single-content {
+        padding: 1.5rem;
+    }
+    
+    .staff-header-inner {
+        grid-template-columns: 1fr;
+        text-align: center;
+        gap: 1.5rem;
+    }
+    
+    .staff-single-image {
+        justify-self: center;
+    }
+    
+    .staff-single-image img,
+    .staff-single-no-image .staff-placeholder-large {
+        max-width: 200px;
+        margin: 0 auto;
+    }
+    
+    .staff-contact-grid {
+        grid-template-columns: 1fr;
+    }
+    
+    .staff-social-links {
+        justify-content: center;
+    }
+}
+
+@media (max-width: 480px) {
+    .staff-card-content {
+        padding: 1rem;
+    }
+    
+    .staff-single-content {
+        padding: 1rem;
+    }
+    
+    .staff-single-name {
+        font-size: 1.5rem;
+    }
+    
+    .staff-social-links {
+        flex-direction: column;
+    }
+    
+    .staff-social-link {
+        justify-content: center;
+    }
+}

--- a/staff-directory/includes/class-staff-acf-fields.php
+++ b/staff-directory/includes/class-staff-acf-fields.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * Staff ACF Fields Class
+ * 
+ * Handles registration of ACF field groups for staff members
+ */
+
+// Prevent direct access
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Staff_ACF_Fields {
+    
+    /**
+     * Constructor
+     */
+    public function __construct() {
+        add_action('acf/init', array($this, 'register_field_groups'));
+    }
+    
+    /**
+     * Register ACF field groups for staff members
+     */
+    public function register_field_groups() {
+        if (function_exists('acf_add_local_field_group')) {
+            
+            // Staff Information Field Group
+            acf_add_local_field_group(array(
+                'key' => 'group_staff_information',
+                'title' => 'Staff Information',
+                'fields' => array(
+                    array(
+                        'key' => 'field_staff_name',
+                        'label' => 'Full Name',
+                        'name' => 'staff_name',
+                        'type' => 'text',
+                        'instructions' => 'Enter the staff member\'s full name',
+                        'required' => 1,
+                        'wrapper' => array(
+                            'width' => '50',
+                        ),
+                    ),
+                    array(
+                        'key' => 'field_staff_title',
+                        'label' => 'Job Title',
+                        'name' => 'staff_title',
+                        'type' => 'text',
+                        'instructions' => 'Enter the staff member\'s job title or position',
+                        'required' => 1,
+                        'wrapper' => array(
+                            'width' => '50',
+                        ),
+                    ),
+                    array(
+                        'key' => 'field_staff_email',
+                        'label' => 'Email Address',
+                        'name' => 'staff_email',
+                        'type' => 'email',
+                        'instructions' => 'Enter the staff member\'s email address',
+                        'required' => 1,
+                        'wrapper' => array(
+                            'width' => '50',
+                        ),
+                    ),
+                    array(
+                        'key' => 'field_staff_phone',
+                        'label' => 'Phone Number',
+                        'name' => 'staff_phone',
+                        'type' => 'text',
+                        'instructions' => 'Enter the staff member\'s phone number',
+                        'required' => 0,
+                        'wrapper' => array(
+                            'width' => '50',
+                        ),
+                    ),
+                    array(
+                        'key' => 'field_staff_birthdate',
+                        'label' => 'Birth Date',
+                        'name' => 'staff_birthdate',
+                        'type' => 'date_picker',
+                        'instructions' => 'Select the staff member\'s birth date',
+                        'required' => 0,
+                        'display_format' => 'F j, Y',
+                        'return_format' => 'Y-m-d',
+                        'first_day' => 1,
+                        'wrapper' => array(
+                            'width' => '50',
+                        ),
+                    ),
+                    array(
+                        'key' => 'field_staff_department',
+                        'label' => 'Department',
+                        'name' => 'staff_department',
+                        'type' => 'select',
+                        'instructions' => 'Select the staff member\'s department',
+                        'required' => 0,
+                        'choices' => array(
+                            'executive' => 'Executive',
+                            'marketing' => 'Marketing',
+                            'sales' => 'Sales',
+                            'hr' => 'Human Resources',
+                            'it' => 'Information Technology',
+                            'finance' => 'Finance',
+                            'operations' => 'Operations',
+                            'customer-service' => 'Customer Service',
+                            'other' => 'Other',
+                        ),
+                        'default_value' => array(),
+                        'allow_null' => 1,
+                        'multiple' => 0,
+                        'ui' => 1,
+                        'return_format' => 'value',
+                        'ajax' => 0,
+                        'placeholder' => 'Select Department',
+                        'wrapper' => array(
+                            'width' => '50',
+                        ),
+                    ),
+                    array(
+                        'key' => 'field_staff_bio',
+                        'label' => 'Biography',
+                        'name' => 'staff_bio',
+                        'type' => 'textarea',
+                        'instructions' => 'Enter a brief biography or description of the staff member',
+                        'required' => 0,
+                        'rows' => 4,
+                        'new_lines' => 'wpautop',
+                    ),
+                ),
+                'location' => array(
+                    array(
+                        array(
+                            'param' => 'post_type',
+                            'operator' => '==',
+                            'value' => 'staff',
+                        ),
+                    ),
+                ),
+                'menu_order' => 0,
+                'position' => 'normal',
+                'style' => 'default',
+                'label_placement' => 'top',
+                'instruction_placement' => 'label',
+                'hide_on_screen' => '',
+                'active' => true,
+                'description' => '',
+            ));
+            
+            // Social Media Links Field Group
+            acf_add_local_field_group(array(
+                'key' => 'group_staff_social_media',
+                'title' => 'Social Media Links',
+                'fields' => array(
+                    array(
+                        'key' => 'field_staff_social_links',
+                        'label' => 'Social Media Links',
+                        'name' => 'staff_social_links',
+                        'type' => 'repeater',
+                        'instructions' => 'Add social media links for this staff member',
+                        'required' => 0,
+                        'collapsed' => 'field_social_platform',
+                        'min' => 0,
+                        'max' => 10,
+                        'layout' => 'table',
+                        'button_label' => 'Add Social Link',
+                        'sub_fields' => array(
+                            array(
+                                'key' => 'field_social_platform',
+                                'label' => 'Platform',
+                                'name' => 'platform',
+                                'type' => 'select',
+                                'instructions' => 'Select the social media platform',
+                                'required' => 1,
+                                'choices' => array(
+                                    'linkedin' => 'LinkedIn',
+                                    'twitter' => 'Twitter',
+                                    'facebook' => 'Facebook',
+                                    'instagram' => 'Instagram',
+                                    'github' => 'GitHub',
+                                    'dribbble' => 'Dribbble',
+                                    'behance' => 'Behance',
+                                    'youtube' => 'YouTube',
+                                    'other' => 'Other',
+                                ),
+                                'default_value' => array(),
+                                'allow_null' => 0,
+                                'multiple' => 0,
+                                'ui' => 1,
+                                'return_format' => 'value',
+                                'ajax' => 0,
+                                'placeholder' => '',
+                                'wrapper' => array(
+                                    'width' => '30',
+                                ),
+                            ),
+                            array(
+                                'key' => 'field_social_url',
+                                'label' => 'URL',
+                                'name' => 'url',
+                                'type' => 'url',
+                                'instructions' => 'Enter the full URL to the social media profile',
+                                'required' => 1,
+                                'wrapper' => array(
+                                    'width' => '70',
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+                'location' => array(
+                    array(
+                        array(
+                            'param' => 'post_type',
+                            'operator' => '==',
+                            'value' => 'staff',
+                        ),
+                    ),
+                ),
+                'menu_order' => 1,
+                'position' => 'normal',
+                'style' => 'default',
+                'label_placement' => 'top',
+                'instruction_placement' => 'label',
+                'hide_on_screen' => '',
+                'active' => true,
+                'description' => '',
+            ));
+        }
+    }
+}

--- a/staff-directory/includes/class-staff-post-type.php
+++ b/staff-directory/includes/class-staff-post-type.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Staff Post Type Class
+ * 
+ * Handles registration of the staff custom post type
+ */
+
+// Prevent direct access
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Staff_Post_Type {
+    
+    /**
+     * Constructor
+     */
+    public function __construct() {
+        add_action('init', array($this, 'register_post_type'));
+        add_action('init', array($this, 'register_taxonomy'));
+    }
+    
+    /**
+     * Register the staff custom post type
+     */
+    public function register_post_type() {
+        $labels = array(
+            'name'                  => _x('Staff Members', 'Post type general name', 'staff-directory'),
+            'singular_name'         => _x('Staff Member', 'Post type singular name', 'staff-directory'),
+            'menu_name'             => _x('Staff Directory', 'Admin Menu text', 'staff-directory'),
+            'name_admin_bar'        => _x('Staff Member', 'Add New on Toolbar', 'staff-directory'),
+            'add_new'               => __('Add New', 'staff-directory'),
+            'add_new_item'          => __('Add New Staff Member', 'staff-directory'),
+            'new_item'              => __('New Staff Member', 'staff-directory'),
+            'edit_item'             => __('Edit Staff Member', 'staff-directory'),
+            'view_item'             => __('View Staff Member', 'staff-directory'),
+            'all_items'             => __('All Staff Members', 'staff-directory'),
+            'search_items'          => __('Search Staff Members', 'staff-directory'),
+            'parent_item_colon'     => __('Parent Staff Members:', 'staff-directory'),
+            'not_found'             => __('No staff members found.', 'staff-directory'),
+            'not_found_in_trash'    => __('No staff members found in Trash.', 'staff-directory'),
+            'featured_image'        => _x('Staff Photo', 'Overrides the "Featured Image" phrase', 'staff-directory'),
+            'set_featured_image'    => _x('Set staff photo', 'Overrides the "Set featured image" phrase', 'staff-directory'),
+            'remove_featured_image' => _x('Remove staff photo', 'Overrides the "Remove featured image" phrase', 'staff-directory'),
+            'use_featured_image'    => _x('Use as staff photo', 'Overrides the "Use as featured image" phrase', 'staff-directory'),
+            'archives'              => _x('Staff Member archives', 'The post type archive label', 'staff-directory'),
+            'insert_into_item'      => _x('Insert into staff member', 'Overrides the "Insert into post" phrase', 'staff-directory'),
+            'uploaded_to_this_item' => _x('Uploaded to this staff member', 'Overrides the "Uploaded to this post" phrase', 'staff-directory'),
+            'filter_items_list'     => _x('Filter staff members list', 'Screen reader text for the filter links', 'staff-directory'),
+            'items_list_navigation' => _x('Staff members list navigation', 'Screen reader text for the pagination', 'staff-directory'),
+            'items_list'            => _x('Staff members list', 'Screen reader text for the items list', 'staff-directory'),
+        );
+        
+        $args = array(
+            'labels'             => $labels,
+            'public'             => true,
+            'publicly_queryable' => true,
+            'show_ui'            => true,
+            'show_in_menu'       => true,
+            'show_in_rest'       => true,
+            'query_var'          => true,
+            'rewrite'            => array('slug' => 'staff'),
+            'capability_type'    => 'post',
+            'has_archive'        => false, // We'll use shortcode instead
+            'hierarchical'       => false,
+            'menu_position'      => 20,
+            'menu_icon'          => 'dashicons-groups',
+            'supports'           => array(
+                'title',
+                'editor',
+                'thumbnail',
+                'page-attributes', // Enables menu_order for custom ordering
+            ),
+            'show_in_customizer' => false,
+        );
+        
+        register_post_type('staff', $args);
+    }
+    
+    /**
+     * Register department taxonomy for staff members
+     */
+    public function register_taxonomy() {
+        $labels = array(
+            'name'              => _x('Departments', 'taxonomy general name', 'staff-directory'),
+            'singular_name'     => _x('Department', 'taxonomy singular name', 'staff-directory'),
+            'search_items'      => __('Search Departments', 'staff-directory'),
+            'all_items'         => __('All Departments', 'staff-directory'),
+            'parent_item'       => __('Parent Department', 'staff-directory'),
+            'parent_item_colon' => __('Parent Department:', 'staff-directory'),
+            'edit_item'         => __('Edit Department', 'staff-directory'),
+            'update_item'       => __('Update Department', 'staff-directory'),
+            'add_new_item'      => __('Add New Department', 'staff-directory'),
+            'new_item_name'     => __('New Department Name', 'staff-directory'),
+            'menu_name'         => __('Departments', 'staff-directory'),
+        );
+        
+        $args = array(
+            'hierarchical'      => true,
+            'labels'            => $labels,
+            'show_ui'           => true,
+            'show_admin_column' => true,
+            'show_in_rest'      => true,
+            'query_var'         => true,
+            'rewrite'           => array('slug' => 'department'),
+        );
+        
+        register_taxonomy('staff_department', array('staff'), $args);
+    }
+}

--- a/staff-directory/includes/class-staff-shortcode.php
+++ b/staff-directory/includes/class-staff-shortcode.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Staff Shortcode Class
+ * 
+ * Handles the [staff_directory] shortcode functionality
+ */
+
+// Prevent direct access
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Staff_Shortcode {
+    
+    /**
+     * Constructor
+     */
+    public function __construct() {
+        add_shortcode('staff_directory', array($this, 'render_shortcode'));
+        add_action('wp_enqueue_scripts', array($this, 'enqueue_styles'));
+    }
+    
+    /**
+     * Enqueue frontend styles
+     */
+    public function enqueue_styles() {
+        wp_enqueue_style(
+            'staff-directory-styles',
+            STAFF_DIRECTORY_PLUGIN_URL . 'assets/css/staff-directory.css',
+            array(),
+            STAFF_DIRECTORY_VERSION
+        );
+    }
+    
+    /**
+     * Render the staff directory shortcode
+     */
+    public function render_shortcode($atts) {
+        // Parse shortcode attributes
+        $atts = shortcode_atts(array(
+            'orderby' => 'menu_order',
+            'order' => 'ASC',
+            'limit' => -1,
+            'columns' => 3,
+            'department' => '',
+        ), $atts, 'staff_directory');
+        
+        // Prepare query arguments
+        $query_args = array(
+            'post_type' => 'staff',
+            'post_status' => 'publish',
+            'posts_per_page' => intval($atts['limit']),
+        );
+        
+        // Handle ordering
+        switch ($atts['orderby']) {
+            case 'alphabetical':
+                $query_args['orderby'] = 'title';
+                $query_args['order'] = 'ASC';
+                break;
+            case 'department':
+                $query_args['meta_key'] = 'staff_department';
+                $query_args['orderby'] = 'meta_value';
+                $query_args['order'] = 'ASC';
+                break;
+            case 'menu_order':
+            default:
+                $query_args['orderby'] = 'menu_order';
+                $query_args['order'] = $atts['order'];
+                break;
+        }
+        
+        // Filter by department if specified
+        if (!empty($atts['department'])) {
+            $query_args['meta_query'] = array(
+                array(
+                    'key' => 'staff_department',
+                    'value' => $atts['department'],
+                    'compare' => '='
+                )
+            );
+        }
+        
+        // Execute query
+        $staff_query = new WP_Query($query_args);
+        
+        if (!$staff_query->have_posts()) {
+            return '<p class="staff-directory-no-results">' . __('No staff members found.', 'staff-directory') . '</p>';
+        }
+        
+        // Start output buffering
+        ob_start();
+        
+        // Generate grid classes
+        $columns = max(1, min(6, intval($atts['columns'])));
+        $grid_class = 'staff-directory-grid staff-directory-columns-' . $columns;
+        
+        ?>
+        <div class="staff-directory-container">
+            <div class="<?php echo esc_attr($grid_class); ?>">
+                <?php while ($staff_query->have_posts()) : $staff_query->the_post(); ?>
+                    <?php $this->render_staff_card(get_the_ID()); ?>
+                <?php endwhile; ?>
+            </div>
+        </div>
+        <?php
+        
+        // Clean up
+        wp_reset_postdata();
+        
+        return ob_get_clean();
+    }
+    
+    /**
+     * Render individual staff card
+     */
+    private function render_staff_card($post_id) {
+        // Get ACF fields
+        $staff_name = get_field('staff_name', $post_id);
+        $staff_title = get_field('staff_title', $post_id);
+        $staff_email = get_field('staff_email', $post_id);
+        $staff_department = get_field('staff_department', $post_id);
+        $featured_image = get_the_post_thumbnail($post_id, 'medium');
+        
+        // Use post title as fallback for name
+        if (empty($staff_name)) {
+            $staff_name = get_the_title($post_id);
+        }
+        
+        // Get permalink for single page
+        $permalink = get_permalink($post_id);
+        
+        ?>
+        <div class="staff-directory-card">
+            <div class="staff-card-inner">
+                <?php if ($featured_image) : ?>
+                    <div class="staff-card-image">
+                        <a href="<?php echo esc_url($permalink); ?>">
+                            <?php echo $featured_image; ?>
+                        </a>
+                    </div>
+                <?php else : ?>
+                    <div class="staff-card-image staff-card-no-image">
+                        <a href="<?php echo esc_url($permalink); ?>">
+                            <div class="staff-placeholder-image">
+                                <span class="staff-placeholder-icon">👤</span>
+                            </div>
+                        </a>
+                    </div>
+                <?php endif; ?>
+                
+                <div class="staff-card-content">
+                    <h3 class="staff-card-name">
+                        <a href="<?php echo esc_url($permalink); ?>">
+                            <?php echo esc_html($staff_name); ?>
+                        </a>
+                    </h3>
+                    
+                    <?php if ($staff_title) : ?>
+                        <p class="staff-card-title"><?php echo esc_html($staff_title); ?></p>
+                    <?php endif; ?>
+                    
+                    <?php if ($staff_department) : ?>
+                        <p class="staff-card-department"><?php echo esc_html($this->format_department($staff_department)); ?></p>
+                    <?php endif; ?>
+                    
+                    <?php if ($staff_email) : ?>
+                        <p class="staff-card-email">
+                            <a href="mailto:<?php echo esc_attr($staff_email); ?>">
+                                <?php echo esc_html($staff_email); ?>
+                            </a>
+                        </p>
+                    <?php endif; ?>
+                    
+                    <div class="staff-card-actions">
+                        <a href="<?php echo esc_url($permalink); ?>" class="staff-card-link">
+                            <?php _e('View Profile', 'staff-directory'); ?>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <?php
+    }
+    
+    /**
+     * Format department name for display
+     */
+    private function format_department($department) {
+        $departments = array(
+            'executive' => 'Executive',
+            'marketing' => 'Marketing',
+            'sales' => 'Sales',
+            'hr' => 'Human Resources',
+            'it' => 'Information Technology',
+            'finance' => 'Finance',
+            'operations' => 'Operations',
+            'customer-service' => 'Customer Service',
+            'other' => 'Other',
+        );
+        
+        return isset($departments[$department]) ? $departments[$department] : ucfirst($department);
+    }
+}

--- a/staff-directory/includes/class-staff-templates.php
+++ b/staff-directory/includes/class-staff-templates.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Staff Templates Class
+ * 
+ * Handles template loading for staff post type
+ */
+
+// Prevent direct access
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Staff_Templates {
+    
+    /**
+     * Constructor
+     */
+    public function __construct() {
+        add_filter('single_template', array($this, 'load_staff_template'));
+        add_filter('template_include', array($this, 'template_include'));
+    }
+    
+    /**
+     * Load custom template for staff post type
+     */
+    public function load_staff_template($template) {
+        if (is_singular('staff')) {
+            $plugin_template = STAFF_DIRECTORY_PLUGIN_DIR . 'templates/single-staff.php';
+            if (file_exists($plugin_template)) {
+                return $plugin_template;
+            }
+        }
+        return $template;
+    }
+    
+    /**
+     * Include custom templates
+     */
+    public function template_include($template) {
+        if (is_singular('staff')) {
+            $plugin_template = STAFF_DIRECTORY_PLUGIN_DIR . 'templates/single-staff.php';
+            if (file_exists($plugin_template)) {
+                return $plugin_template;
+            }
+        }
+        return $template;
+    }
+}

--- a/staff-directory/staff-directory.php
+++ b/staff-directory/staff-directory.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Plugin Name: Staff Directory
+ * Plugin URI: https://github.com/OrasesWPDev/aw-demo
+ * Description: A WordPress plugin to manage staff members with ACF Pro integration. Features custom post type, shortcode display, and individual staff pages.
+ * Version: 1.0.1
+ * Author: Orases
+ * License: GPL v2 or later
+ * Requires at least: 5.0
+ * Tested up to: 6.4
+ * Requires PHP: 7.4
+ * Text Domain: staff-directory
+ */
+
+// Prevent direct access
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+// Define plugin constants
+define('STAFF_DIRECTORY_VERSION', '1.0.1');
+define('STAFF_DIRECTORY_PLUGIN_DIR', plugin_dir_path(__FILE__));
+define('STAFF_DIRECTORY_PLUGIN_URL', plugin_dir_url(__FILE__));
+
+/**
+ * Main Staff Directory Plugin Class
+ */
+class Staff_Directory_Plugin {
+    
+    /**
+     * Single instance of the plugin
+     */
+    private static $instance = null;
+    
+    /**
+     * Get singleton instance
+     */
+    public static function get_instance() {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+    
+    /**
+     * Constructor
+     */
+    private function __construct() {
+        add_action('plugins_loaded', array($this, 'init'));
+        register_activation_hook(__FILE__, array($this, 'activate'));
+        register_deactivation_hook(__FILE__, array($this, 'deactivate'));
+    }
+    
+    /**
+     * Initialize plugin
+     */
+    public function init() {
+        // Check if ACF Pro is active
+        if (!class_exists('ACF')) {
+            add_action('admin_notices', array($this, 'acf_missing_notice'));
+            return;
+        }
+        
+        // Load plugin classes
+        $this->load_classes();
+        
+        // Initialize components
+        new Staff_Post_Type();
+        new Staff_ACF_Fields();
+        new Staff_Shortcode();
+        new Staff_Templates();
+    }
+    
+    /**
+     * Load required classes
+     */
+    private function load_classes() {
+        require_once STAFF_DIRECTORY_PLUGIN_DIR . 'includes/class-staff-post-type.php';
+        require_once STAFF_DIRECTORY_PLUGIN_DIR . 'includes/class-staff-acf-fields.php';
+        require_once STAFF_DIRECTORY_PLUGIN_DIR . 'includes/class-staff-shortcode.php';
+        require_once STAFF_DIRECTORY_PLUGIN_DIR . 'includes/class-staff-templates.php';
+    }
+    
+    /**
+     * Plugin activation
+     */
+    public function activate() {
+        // Flush rewrite rules to register custom post type
+        flush_rewrite_rules();
+    }
+    
+    /**
+     * Plugin deactivation
+     */
+    public function deactivate() {
+        // Flush rewrite rules
+        flush_rewrite_rules();
+    }
+    
+    /**
+     * Show admin notice if ACF Pro is not active
+     */
+    public function acf_missing_notice() {
+        ?>
+        <div class="notice notice-error">
+            <p><?php _e('Staff Directory plugin requires Advanced Custom Fields Pro to be installed and activated.', 'staff-directory'); ?></p>
+        </div>
+        <?php
+    }
+}
+
+// Initialize the plugin
+Staff_Directory_Plugin::get_instance();

--- a/staff-directory/templates/single-staff.php
+++ b/staff-directory/templates/single-staff.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * Single Staff Member Template
+ * 
+ * Template for displaying individual staff member pages
+ */
+
+get_header(); ?>
+
+<div class="staff-single-container">
+    <?php while (have_posts()) : the_post(); ?>
+        
+        <article id="post-<?php the_ID(); ?>" <?php post_class('staff-single-post'); ?>>
+            
+            <div class="staff-single-content">
+                
+                <!-- Staff Header Section -->
+                <header class="staff-single-header">
+                    <div class="staff-header-inner">
+                        
+                        <?php if (has_post_thumbnail()) : ?>
+                            <div class="staff-single-image">
+                                <?php the_post_thumbnail('large', array('class' => 'staff-photo')); ?>
+                            </div>
+                        <?php else : ?>
+                            <div class="staff-single-image staff-single-no-image">
+                                <div class="staff-placeholder-large">
+                                    <span class="staff-placeholder-icon">👤</span>
+                                </div>
+                            </div>
+                        <?php endif; ?>
+                        
+                        <div class="staff-header-info">
+                            <?php
+                            $staff_name = get_field('staff_name');
+                            $staff_title = get_field('staff_title');
+                            $staff_department = get_field('staff_department');
+                            ?>
+                            
+                            <h1 class="staff-single-name">
+                                <?php echo $staff_name ? esc_html($staff_name) : get_the_title(); ?>
+                            </h1>
+                            
+                            <?php if ($staff_title) : ?>
+                                <p class="staff-single-title"><?php echo esc_html($staff_title); ?></p>
+                            <?php endif; ?>
+                            
+                            <?php if ($staff_department) : ?>
+                                <p class="staff-single-department">
+                                    <strong><?php _e('Department:', 'staff-directory'); ?></strong>
+                                    <?php echo esc_html($this->format_department($staff_department)); ?>
+                                </p>
+                            <?php endif; ?>
+                        </div>
+                        
+                    </div>
+                </header>
+                
+                <!-- Staff Contact Information -->
+                <section class="staff-contact-section">
+                    <h2><?php _e('Contact Information', 'staff-directory'); ?></h2>
+                    
+                    <div class="staff-contact-grid">
+                        <?php
+                        $staff_email = get_field('staff_email');
+                        $staff_phone = get_field('staff_phone');
+                        $staff_birthdate = get_field('staff_birthdate');
+                        ?>
+                        
+                        <?php if ($staff_email) : ?>
+                            <div class="staff-contact-item">
+                                <strong><?php _e('Email:', 'staff-directory'); ?></strong>
+                                <a href="mailto:<?php echo esc_attr($staff_email); ?>">
+                                    <?php echo esc_html($staff_email); ?>
+                                </a>
+                            </div>
+                        <?php endif; ?>
+                        
+                        <?php if ($staff_phone) : ?>
+                            <div class="staff-contact-item">
+                                <strong><?php _e('Phone:', 'staff-directory'); ?></strong>
+                                <a href="tel:<?php echo esc_attr($staff_phone); ?>">
+                                    <?php echo esc_html($staff_phone); ?>
+                                </a>
+                            </div>
+                        <?php endif; ?>
+                        
+                        <?php if ($staff_birthdate) : ?>
+                            <div class="staff-contact-item">
+                                <strong><?php _e('Birthday:', 'staff-directory'); ?></strong>
+                                <?php echo date('F j', strtotime($staff_birthdate)); ?>
+                            </div>
+                        <?php endif; ?>
+                        
+                    </div>
+                </section>
+                
+                <!-- Staff Biography -->
+                <?php 
+                $staff_bio = get_field('staff_bio');
+                $post_content = get_the_content();
+                ?>
+                
+                <?php if ($staff_bio || $post_content) : ?>
+                    <section class="staff-bio-section">
+                        <h2><?php _e('About', 'staff-directory'); ?></h2>
+                        
+                        <?php if ($staff_bio) : ?>
+                            <div class="staff-bio-content">
+                                <?php echo wp_kses_post($staff_bio); ?>
+                            </div>
+                        <?php endif; ?>
+                        
+                        <?php if ($post_content) : ?>
+                            <div class="staff-post-content">
+                                <?php the_content(); ?>
+                            </div>
+                        <?php endif; ?>
+                    </section>
+                <?php endif; ?>
+                
+                <!-- Social Media Links -->
+                <?php
+                $social_links = get_field('staff_social_links');
+                if ($social_links && is_array($social_links)) :
+                ?>
+                    <section class="staff-social-section">
+                        <h2><?php _e('Connect', 'staff-directory'); ?></h2>
+                        
+                        <div class="staff-social-links">
+                            <?php foreach ($social_links as $social_link) : ?>
+                                <?php if (!empty($social_link['url']) && !empty($social_link['platform'])) : ?>
+                                    <a href="<?php echo esc_url($social_link['url']); ?>" 
+                                       target="_blank" 
+                                       rel="noopener noreferrer"
+                                       class="staff-social-link staff-social-<?php echo esc_attr($social_link['platform']); ?>">
+                                        <span class="staff-social-icon">
+                                            <?php echo $this->get_social_icon($social_link['platform']); ?>
+                                        </span>
+                                        <span class="staff-social-label">
+                                            <?php echo esc_html(ucfirst($social_link['platform'])); ?>
+                                        </span>
+                                    </a>
+                                <?php endif; ?>
+                            <?php endforeach; ?>
+                        </div>
+                    </section>
+                <?php endif; ?>
+                
+                <!-- Back to Directory Link -->
+                <nav class="staff-navigation">
+                    <a href="#" onclick="history.back()" class="staff-back-link">
+                        ← <?php _e('Back to Staff Directory', 'staff-directory'); ?>
+                    </a>
+                </nav>
+                
+            </div>
+            
+        </article>
+        
+    <?php endwhile; ?>
+</div>
+
+<?php get_footer(); ?>
+
+<?php
+/**
+ * Helper functions for the template
+ */
+
+function format_department($department) {
+    $departments = array(
+        'executive' => 'Executive',
+        'marketing' => 'Marketing',
+        'sales' => 'Sales',
+        'hr' => 'Human Resources',
+        'it' => 'Information Technology',
+        'finance' => 'Finance',
+        'operations' => 'Operations',
+        'customer-service' => 'Customer Service',
+        'other' => 'Other',
+    );
+    
+    return isset($departments[$department]) ? $departments[$department] : ucfirst($department);
+}
+
+function get_social_icon($platform) {
+    $icons = array(
+        'linkedin' => '🔗',
+        'twitter' => '🐦',
+        'facebook' => '📘',
+        'instagram' => '📷',
+        'github' => '⚡',
+        'dribbble' => '🏀',
+        'behance' => '🎨',
+        'youtube' => '📺',
+        'other' => '🌐',
+    );
+    
+    return isset($icons[$platform]) ? $icons[$platform] : '🌐';
+}
+?>


### PR DESCRIPTION
## Summary
Complete WordPress plugin for managing staff members with ACF Pro integration.

## What's New
- Staff Directory plugin with custom post type
- ACF Pro fields for comprehensive staff profiles
- Flexible display options via shortcode
- Responsive design for all devices

## Features
✅ **Custom Post Type**: 'staff' with admin-controlled ordering  
✅ **ACF Pro Fields**: Name, email, title, birthdate, department, phone, bio, social links  
✅ **Shortcode**: `[staff_directory]` with sorting options:
   - `orderby="menu_order"` (default)
   - `orderby="alphabetical"`
   - `orderby="department"`
✅ **Single Staff Pages**: Custom template with full profile  
✅ **Responsive Design**: 1-6 column grid layouts  

## Files Added
- `staff-directory/` plugin directory
- Complete documentation in plugin README
- All required PHP classes and templates
- Responsive CSS styling

## Testing
- Install and activate plugin with ACF Pro
- Create staff members and test display options
- Verify responsive design on mobile devices

🤖 Generated with [Claude Code](https://claude.ai/code)